### PR TITLE
docs: label code fences with languages

### DIFF
--- a/Vault/Learnings/Blockchain/coin/Calin_Coin_Test_Log_vA.md
+++ b/Vault/Learnings/Blockchain/coin/Calin_Coin_Test_Log_vA.md
@@ -43,7 +43,7 @@ python calin_coin-a.py
 ```
 
 **Output:**
-```
+```text
 ✅ Calin Coin chain successfully validated.
 Final state: {'Alice': 72, 'Bob': 28}
 Genesis Block Hash: 7c88a4312054f89a2b73b04989cd9b9e1ae437e1048f89fbb4e18a08479de507
@@ -60,7 +60,7 @@ Script runs without errors. Hashes and final state match expected behavior.
 **Goal:** Confirm that output remains consistent across multiple runs.
 
 **Output Sample (x5 runs):**
-```
+```text
 Final state: {'Alice': 72, 'Bob': 28}
 Block #1 Hash: 7a91fc8206c5351293fd11200b33b7192e87fad6545504068a51aba868bc6f72
 ```
@@ -78,7 +78,7 @@ chain[1]['hash'] = "badcafedeadbeef1234567890"
 ```
 
 **Output:**
-```
+```text
 Exception: Hash does not match contents of block 1
 ```
 
@@ -95,7 +95,7 @@ txnBuffer.insert(0, {'Alice': -5, 'Bob': 2})  # Invalid: net ≠ 0
 ```
 
 **Debug Print Output:**
-```
+```text
 ❌ Invalid transaction skipped: {'Alice': -5, 'Bob': 2}
 ✅ Calin Coin chain successfully validated.
 ```

--- a/Vault/Learnings/Blockchain/coin/Calin_Coin_Test_Log_vB.md
+++ b/Vault/Learnings/Blockchain/coin/Calin_Coin_Test_Log_vB.md
@@ -37,8 +37,8 @@ Random Seeds: `random.seed(99)`  , `random.seed(42)`
 **Command:**  
 `python calin_coin-b.py`
 
-**Output:**  
-```
+**Output:**
+```text
 ✅ Calin Coin Chain Validated!
 📦 Final Blockchain State: {'Alice': 33, 'Bob': 67}
 🔗 Genesis Block Hash: 7c88a4312054f89a2b73b04989cd9b9e1ae437e1048f89fbb4e18a08479de507
@@ -56,8 +56,8 @@ Random Seeds: `random.seed(99)`  , `random.seed(42)`
 
 **Goal:** Confirm that output remains consistent across multiple runs.
 
-**Output Sample:**  
-```
+**Output Sample:**
+```text
 ✅ Calin Coin Chain Validated!
 📦 Final Blockchain State: {'Alice': 33, 'Bob': 67}
 🔗 Genesis Block Hash: 7c88a4312054f89a2b73b04989cd9b9e1ae437e1048f89fbb4e18a08479de507
@@ -77,8 +77,8 @@ Random Seeds: `random.seed(99)`  , `random.seed(42)`
 chain[1]['hash'] = "deadbeef0000000000000000000000000000000000000000000000000000000000"
 ```
 
-**Output:**  
-```
+**Output:**
+```text
 ValueError: Block 1 hash mismatch
 ```
 
@@ -97,8 +97,8 @@ ValueError: Block 1 hash mismatch
 txn_pool.insert(0, {"Alice": -999, "Bob": 500})  # Invalid: net ≠ 0
 ```
 
-**Debug Print Output:**  
-```
+**Debug Print Output:**
+```text
 ❌ INVALID: {'Alice': -999, 'Bob': 500}
 ```
 
@@ -117,8 +117,8 @@ txn_pool.insert(0, {"Alice": -999, "Bob": 500})  # Invalid: net ≠ 0
 chain[1]['contents']['txns'][0]['Alice'] = 5000
 ```
 
-**Output:**  
-```
+**Output:**
+```text
 ValueError: Invalid transaction
 ```
 

--- a/Vault/Learnings/Setups/Setup-Selenium_PowerShell.md
+++ b/Vault/Learnings/Setups/Setup-Selenium_PowerShell.md
@@ -41,7 +41,7 @@ Go to → https://github.com/mozilla/geckodriver/releases
 Download the **latest Windows 64-bit** `.zip`.
 
 **B. Extract `geckodriver.exe` to:**
-```
+```powershell
 C:\WebDrivers\geckodriver.exe
 ```
 
@@ -68,10 +68,9 @@ msedge --version
 Go to → https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
 
 **C. Extract `msedgedriver.exe` to:**
-```
+```powershell
 C:\WebDrivers\msedgedriver.exe
 ```
-
 **D. Ensure folder is in your PATH.**
 
 **E. Test it:**

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Programming Languages/Python/Functional Programming/note_py_decorators.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Programming Languages/Python/Functional Programming/note_py_decorators.md
@@ -56,7 +56,7 @@ greet()
 ```
 
 🧠 Output:
-```
+```text
 Before the call
 Hello!
 After the call

--- a/Vault/System/Backend/Scripts/Plugins/draft-vaultos/test/Folder Scaffolding/README.md
+++ b/Vault/System/Backend/Scripts/Plugins/draft-vaultos/test/Folder Scaffolding/README.md
@@ -9,7 +9,7 @@ This is an Obsidian community plugin designed to scaffold a clean, modular folde
 ### 📁 1. Install the Plugin
 Place the extracted plugin folder here:
 
-```
+```bash
 <YourVault>/.obsidian/plugins/vault-structure-builder/
 ```
 
@@ -26,7 +26,7 @@ npm run build
 ```
 
 If successful, this will output:
-```
+```bash
 dist/main.js  ✅
 ```
 
@@ -46,7 +46,7 @@ dist/main.js  ✅
 
 Open the Command Palette (Ctrl+P or Cmd+P) and search for:
 
-```
+```bash
 🧱 Generate Vault Structure
 ```
 
@@ -62,7 +62,7 @@ This will:
 
 In `VAULT/System/Backend/Scripts/`, there's also:
 
-```
+```bash
 vault-like-structure.sh
 ```
 


### PR DESCRIPTION
## Summary
- add explicit `text` fences in Calin Coin test logs
- specify PowerShell code blocks in selenium setup
- mark command snippets as bash in vault structure builder docs
- clarify decorator example output with `text` fences

## Testing
- `git status --short`