### PR TITLE
Fix newline at EOF in bash scripts

### DIFF
--- a/Vault/Learnings/Automations/Logging/changelog_watcher.sh
+++ b/Vault/Learnings/Automations/Logging/changelog_watcher.sh
@@ -29,3 +29,4 @@ find "$VAULT_DIR" -type f -name "*.md" | while read -r file; do
     fi
   fi
 done
+

--- a/Vault/System/Backend/Scripts/Structure Builder Scripts/Vault Structure Construction/Notes Section/structure-builder_Notes.bash
+++ b/Vault/System/Backend/Scripts/Structure Builder Scripts/Vault Structure Construction/Notes Section/structure-builder_Notes.bash
@@ -96,3 +96,4 @@ echo "🔍 Check the structure and adjust as needed."
 # The author is not responsible for any data loss or corruption that may occur.
 # Use at your own risk.
 # -----------------------------------------------------------------------------------
+


### PR DESCRIPTION
## Summary
- ensure newline at EOF for `changelog_watcher.sh`
- ensure newline at EOF for `structure-builder_Notes.bash`

## Testing
- `true`
