### PR TITLE
Add Cinema and TV notes

### DIFF
--- a/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Cinema and TV.md
+++ b/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Cinema and TV.md
@@ -1,0 +1,12 @@
+---
+title: "Cinema and TV"
+created: 2025-06-24
+type: topic
+tags: [topic]
+parent: "Performing Arts"
+children: []
+---
+
+# Cinema and TV
+
+This is the **Cinema and TV** section of the Performing Arts.

--- a/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Intro to Cinema and TV.md
+++ b/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Intro to Cinema and TV.md
@@ -1,0 +1,12 @@
+---
+title: "Intro to Cinema and TV"
+created: 2025-06-24
+type: note
+tags: [note, "Cinema and TV"]
+parent: "Cinema and TV"
+children: []
+---
+
+# Intro to Cinema and TV
+
+This note introduces the topic of **Cinema and TV** within the broader Performing Arts context.

--- a/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Intro to Reality Television.md
+++ b/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Intro to Reality Television.md
@@ -1,0 +1,12 @@
+---
+title: "Intro to Reality Television"
+created: 2025-06-24
+type: note
+tags: [note, "Reality Television"]
+parent: "Reality Television"
+children: []
+---
+
+# Intro to Reality Television
+
+This note introduces the topic of **Reality Television** within the Cinema and TV context.

--- a/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Reality Television.md
+++ b/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Reality Television.md
@@ -1,0 +1,12 @@
+---
+title: "Reality Television"
+created: 2025-06-24
+type: note
+tags: [note, "Reality Television"]
+parent: "Cinema and TV"
+children: []
+---
+
+# Reality Television
+
+This note covers **Reality Television** topics within Cinema and TV.

--- a/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Survivor/Intro to Survivor.md
+++ b/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Survivor/Intro to Survivor.md
@@ -1,0 +1,12 @@
+---
+title: "Intro to Survivor"
+created: 2025-06-24
+type: note
+tags: [note, Survivor]
+parent: "Survivor"
+children: []
+---
+
+# Intro to Survivor
+
+This note introduces the **Survivor** television series within Reality Television.

--- a/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Survivor/Survivor.md
+++ b/Vault/Notes/Personal Encyclopedia/Arts and Culture/Performing Arts/Cinema and TV/Reality Television/Survivor/Survivor.md
@@ -1,0 +1,12 @@
+---
+title: "Survivor"
+created: 2025-06-24
+type: note
+tags: [note, Survivor]
+parent: "Reality Television"
+children: []
+---
+
+# Survivor
+
+This note explores the **Survivor** television series.

--- a/Vault/System/Backend/Scripts/Structure Builder Scripts/Vault Structure Construction/Notes Section/Personal Encyclopedia/structure-builder_Personal-Encyclopedia.bash
+++ b/Vault/System/Backend/Scripts/Structure Builder Scripts/Vault Structure Construction/Notes Section/Personal Encyclopedia/structure-builder_Personal-Encyclopedia.bash
@@ -113,6 +113,7 @@ ARTS_TOPICS=(
   ["Built and Decorative Arts"]="Architecture|Interior Design|Landscaping and Garden Design|Urbanism|Glasswork|Metalworking|Ceramics and Pottery|Woodworking|Jewelry Design"
   ["Visual Arts"]="Drawing|Painting|Printmaking|Sculpture|Textile Arts|3D Art|Digital Arts|Mixed Media|Illustration|Calligraphy"
   ["Performing Arts"]="Dance|Theatre|Opera|Music|Cinema|Performance Art|Improv"
+  ["Cinema and TV"]="Reality Television"
   ["Literary Arts"]="Literature|Poetry|Storytelling"
   ["Meta-Arts Theory Systems Institutions"]="Art History|Symbolism in Arts|Conceptualizing an Art Project|Artistic Practices and Methodologies|Artistic Movements and Styles|The Art Scene and Communities|Art Curation and Exhibition|Funding and Granting Arts"
 )
@@ -269,7 +270,7 @@ for domain in "${!TOPICS[@]}"; do
     create_markdown_pair "$topic_path" "$topic" "topic" "$domain"
   done
 
-  if [[ "$domain" == "Arts & Culture" ]]; then
+  if [[ "$domain" == "Arts and Culture" ]]; then
     create_structure_from_map "$domain_path" "$domain" ARTS_TOPICS
   elif [[ "$domain" == "Economics & Business" ]]; then
     create_structure_from_map "$domain_path" "$domain" ECON_TOPICS


### PR DESCRIPTION
## Summary
- extend `ARTS_TOPICS` with new `Cinema and TV` entry
- fix conditional string for `Arts and Culture`
- create notes for Cinema and TV with Reality Television and Survivor examples