### PR TITLE
Add Vault Engineering encyclopedia section

### DIFF
--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Computing and AI.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Computing and AI.md
@@ -30,6 +30,7 @@ strategic side of information technology and artificial intelligence.
 - [[Networks]]
 - [[Programming Languages]]
 - [[Version Control]]
+- [[Vault Engineering]]
 
 ## 📚 Glossaries
 

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Automation Pipeline Design.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Automation Pipeline Design.md
@@ -1,0 +1,12 @@
+---
+title: "Automation Pipeline Design"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Automation Pipeline Design
+
+Placeholder content for Automation Pipeline Design.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Learning System Design.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Learning System Design.md
@@ -1,0 +1,12 @@
+---
+title: "Learning System Design"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Learning System Design
+
+Placeholder content for Learning System Design.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Metadata Governance.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Metadata Governance.md
@@ -1,0 +1,12 @@
+---
+title: "Metadata Governance"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Metadata Governance
+
+Placeholder content for Metadata Governance.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Modular Plugin Architecture.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Modular Plugin Architecture.md
@@ -1,0 +1,12 @@
+---
+title: "Modular Plugin Architecture"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Modular Plugin Architecture
+
+Placeholder content for Modular Plugin Architecture.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Project Template Library.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Project Template Library.md
@@ -1,0 +1,12 @@
+---
+title: "Project Template Library"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Project Template Library
+
+Placeholder content for Project Template Library.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Second Brain Architecture.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Second Brain Architecture.md
@@ -1,0 +1,12 @@
+---
+title: "Second Brain Architecture"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Second Brain Architecture
+
+Placeholder content for Second Brain Architecture.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Vault Engineering Utilities.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Vault Engineering Utilities.md
@@ -1,0 +1,12 @@
+---
+title: "Vault Engineering Utilities"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Vault Engineering Utilities
+
+Placeholder content for Vault Engineering Utilities.

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Vault Engineering.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Vault Engineering.md
@@ -1,0 +1,5 @@
+---
+tags: MOCs
+---
+```folder-index-content
+```

--- a/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Veridonia Universe Framework.md
+++ b/Vault/Notes/Personal Encyclopedia/Science and Technology/Computing and AI/Vault Engineering/Veridonia Universe Framework.md
@@ -1,0 +1,12 @@
+---
+title: "Veridonia Universe Framework"
+created: 2025-06-08
+type: note
+tags: [note, placeholder]
+parent: "Vault Engineering"
+children: []
+---
+
+# Veridonia Universe Framework
+
+Placeholder content for Veridonia Universe Framework.


### PR DESCRIPTION
## Summary
- add Vault Engineering section under personal encyclopedia
- scaffold placeholder entries for architecture, utilities, and metadata
- link new section from Computing and AI index

## Testing
- `git log -2 --stat`